### PR TITLE
Fix missing comma in RegisterSubBlock::Array codegen.

### DIFF
--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -864,7 +864,7 @@ pub fn generate_code(block: &ValidatedRegisterBlock, options: Options) -> TokenS
                         pub fn #subblock_fn_name(&self, index: usize) -> #subblock_name<&TMmio> {
                             assert!(index < #len);
                             #subblock_name{
-                                ptr: unsafe { self.ptr.add((#start_offset + index * #stride) / core::mem::size_of::<#raw_ptr_type>()) }
+                                ptr: unsafe { self.ptr.add((#start_offset + index * #stride) / core::mem::size_of::<#raw_ptr_type>()) },
                                 mmio: core::borrow::Borrow::borrow(&self.mmio),
                             }
                         }


### PR DESCRIPTION
This feature isn't used by Caliptra, so we didn't notice the regression.