### PR TITLE
Add ValidatedRegisterBlock::extract_array().

### DIFF
--- a/lib/schema/src/validate.rs
+++ b/lib/schema/src/validate.rs
@@ -391,7 +391,9 @@ impl ValidatedRegisterBlock {
                 // Keep this register in self.registers
                 return true;
             }
-            let Ok(index) = reg.name[reg_name.len()..].parse::<usize>() else { return true; };
+            let Ok(index) = reg.name[reg_name.len()..].parse::<usize>() else {
+                return true;
+            };
 
             let reg_name = reg_name.trim_start_matches(block_name);
             instances_by_name


### PR DESCRIPTION
This can be used to convert from contiguously defined registers (for example, [data0, data1, data2]) into a register array.