### PR TITLE
Trim starting '!' characters out of doc comments.

### DIFF
--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -376,7 +376,11 @@ fn generate_register(reg: &RegisterType) -> TokenStream {
         let access_expr = quote! {
             (self.0 >> #position) & #mask
         };
-        let comment = &field.comment.replace("<br>", "\n");
+        let comment = field
+            .comment
+            .replace("<br>", "\n")
+            .trim_start_matches('!')
+            .to_string();
         if field.ty.can_read() {
             read_val_tokens.extend(quote! {
                 #[doc = #comment]
@@ -644,7 +648,7 @@ fn generate_block_registers(
             .replace("crate::", "");
         let comment = format!(
             "{}\n\nRead value: [`{read_type_str}`]; Write value: [`{write_type_str}`]",
-            reg.comment.replace("<br>", "\n")
+            reg.comment.replace("<br>", "\n").trim_start_matches('!')
         );
 
         let result_type = generate_array_type(


### PR DESCRIPTION
These have special meaning to the rustdoc compiler, and must be avoided.