### PR TITLE
Fix the constraints on `ptr`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,8 @@ impl<TReg: RegType, TMmio: Mmio + Default> RegRef<TReg, TMmio> {
             ptr,
         }
     }
-
+}
+impl<TReg: RegType, TMmio: Mmio> RegRef<TReg, TMmio> {
     /// Returns a pointer to the underlying MMIO register.
     ///
     /// # Safety


### PR DESCRIPTION
Remove the `Default` constraint on the impl for the `ptr` method.