### PR TITLE
Constify *ReadVal and *WriteVal.

### DIFF
--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -847,7 +847,7 @@ pub fn generate_code(block: &ValidatedRegisterBlock, options: Options) -> TokenS
                     /// Returns a register block that can be used to read
                     /// registers from this peripheral, but cannot write.
                     #[inline(always)]
-                    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+                    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio<'_>> {
                         RegisterBlock{
                             ptr: Self::PTR,
                             mmio: core::default::Default::default(),
@@ -857,7 +857,7 @@ pub fn generate_code(block: &ValidatedRegisterBlock, options: Options) -> TokenS
                     /// Return a register block that can be used to read and
                     /// write this peripheral's registers.
                     #[inline(always)]
-                    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+                    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut<'_>> {
                         RegisterBlock{
                             ptr: Self::PTR,
                             mmio: core::default::Default::default(),


### PR DESCRIPTION
In addition to making all the field methods const, this exposes the inner data as `.0`, making it possible to access the raw value without resorting to the From trait (that can't be used from const context).