### PR TITLE
Update rust-toolchain.toml to 1.71..

### DIFF
--- a/lib/codegen/rust-toolchain.toml
+++ b/lib/codegen/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.70"
+channel = "1.71"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/lib/schema/rust-toolchain.toml
+++ b/lib/schema/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.70"
+channel = "1.71"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/lib/systemrdl-parse/rust-toolchain.toml
+++ b/lib/systemrdl-parse/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.70"
+channel = "1.71"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/lib/systemrdl/rust-toolchain.toml
+++ b/lib/systemrdl/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.70"
+channel = "1.71"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.70"
+channel = "1.71"
 targets = ["riscv32imc-unknown-none-elf"]
 profile = "minimal"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This fixes the ci error:

"package `quote v1.0.45` cannot be built because it requires rustc 1.71 or newer"